### PR TITLE
added sbt-spark-package support

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,6 @@
 import sbt._
 import sbt.Keys._
+import sbtsparkpackage.SparkPackagePlugin.autoImport._
 import net.virtualvoid.sbt.graph.Plugin._
 
 object ProjectBuild extends Build {
@@ -12,10 +13,15 @@ object ProjectBuild extends Build {
       version := "0.1.0",
       scalaVersion := "2.10.4",
       crossScalaVersions := Seq("2.10.4", "2.11.5"),
-      libraryDependencies ++= Seq(
-        "org.apache.spark" %% "spark-core" % "1.2.0" % "provided",
-        "org.scalatest" %% "scalatest" % "2.2.1" % "test"
-      ),
+      // sbt-spark-package settings
+      spName := "tresata/spark-sorted",
+      sparkVersion := "1.2.0",
+      sparkComponents += "core",
+      spIncludeMaven := true,
+      spAppendScalaVersion := true,
+      // end sbt-spark-package settings
+      licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"),
+      libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test",
       publishMavenStyle := true,
       pomIncludeRepository := { x => false },
       publishArtifact in Test := false,
@@ -29,14 +35,6 @@ object ProjectBuild extends Build {
       credentials += Credentials(Path.userHome / ".m2" / "credentials_sonatype"),
       pomExtra := (
         <url>https://github.com/tresata/spark-scalding</url>
-        <licenses>
-          <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>  
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-          </license>
-        </licenses>
         <scm>
           <url>git@github.com:tresata/spark-scalding.git</url>
           <connection>scm:git:git@github.com:tresata/spark-scalding.git</connection>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
+
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.1")


### PR DESCRIPTION
Hi!

I added support for the sbt-spark-package plugin with this PR. With this plugin, you can make releases to Spark Packages directly using sbt! No need to go to the website anymore. All you need to do is (since you publish to Maven Central as well) to publish to Maven Central first, using `sbt publish`. Then you can publish to Spark Packages using `sbt spPublish`.

The one thing to be careful about is that the HEAD commit on your local repo must exist on your remote repository as well, so that we can pull in your tree from Github during checks. In addition, one last step is to add a Github personal access token into a credentials file as described in the [README](https://github.com/databricks/sbt-spark-package).

We would love to see your package on the Spark Packages repository as well! (Also, your package will be ranked higher on the website :))

Best,
Burak
