### PR TITLE
Add reduceLeftByKey method

### DIFF
--- a/src/main/scala/com/tresata/spark/sorted/GroupSorted.scala
+++ b/src/main/scala/com/tresata/spark/sorted/GroupSorted.scala
@@ -71,6 +71,9 @@ trait GroupSorted[K, V] extends RDD[(K, V)] {
 
     mapStreamByKey(iter => Iterator(iter.foldLeft(wCreate())(f)))
   }
+
+  def reduceLeftByKey[W >: V: ClassTag](f: (W, V) => W): RDD[(K, W)] = mapStreamByKey(iter => Iterator(iter.reduceLeft(f)))
+
 }
 
 object GroupSorted {

--- a/src/main/scala/com/tresata/spark/sorted/api/java/GroupSorted.scala
+++ b/src/main/scala/com/tresata/spark/sorted/api/java/GroupSorted.scala
@@ -68,4 +68,9 @@ class GroupSorted[K, V](javaPairRDD: JavaPairRDD[K, V], partitioner: Partitioner
     implicit def wClassTag: ClassTag[W] = fakeClassTag[W]
     new JavaPairRDD[K, W](sGroupSorted.foldLeftByKey(w)((w, v) => f.call(w, v)))
   }
+
+  def reduceLeftByKey[W >: V](f: JFunction2[W, V, W]): JavaPairRDD[K, W] = {
+    implicit def wClassTag: ClassTag[W] = fakeClassTag[W]
+    new JavaPairRDD[K, W](sGroupSorted.reduceLeftByKey(f.call))
+  }
 }


### PR DESCRIPTION
Hi!

This PR implements `reduceLeftByKey` method which is similar to `foldLeftByKey` but doesn't use have value.

Though it's very simple in implementation it's usage a lot more straightforward than  `mapStreamByKey(iter => Iterator(iter.reduceLeft(f)))`.
